### PR TITLE
Pass unsafe vault envs

### DIFF
--- a/.plzconfig
+++ b/.plzconfig
@@ -2,7 +2,11 @@
 version = 15.2.0
 
 [go]
-importpath = github.com/sagikazarmark/viperx
+importPath = github.com/sagikazarmark/viperx
+
+[build]
+passUnsafeEnv = VAULT_ADDR
+passUnsafeEnv = VAULT_TOKEN
 
 [buildconfig]
 golangci-lint-version = 1.30.0

--- a/.plzconfig.experimental
+++ b/.plzconfig.experimental
@@ -1,5 +1,5 @@
 [please]
-version = 15.2.1-beta.1
+version = 15.2.1-beta.2
 
 [buildconfig]
 moddown-tool = ///pleasegomod//:moddown

--- a/BUILD
+++ b/BUILD
@@ -6,7 +6,7 @@ github_repo(
 
 http_archive(
     name = "pleasegomod",
-    urls = [f"https://github.com/sagikazarmark/please-go-modules/releases/download/v0.0.4/gogetgen_{CONFIG.HOSTOS}_{CONFIG.HOSTARCH}.tar.gz"],
+    urls = [f"https://github.com/sagikazarmark/please-go-modules/releases/download/v0.0.6/gogetgen_{CONFIG.HOSTOS}_{CONFIG.HOSTARCH}.tar.gz"],
 )
 
 # See https://github.com/thought-machine/please/issues/1173


### PR DESCRIPTION
Pass VAULT_ env vars to the test.

Note: regardless of using PassUnsafeEnv, it does seem to effect incrementality.

See the following commands:

```
❯ plz build --profile experimental //remote/vault:test
Build finished; total time 310ms, incrementality 100.0%. Outputs:
//remote/vault:test:
  plz-out/bin/remote/vault/test
❯ VAULT_TOKEN=asd plz build --profile experimental //remote/vault:test
Build finished; total time 19.48s, incrementality 0.0%. Outputs:
//remote/vault:test:
  plz-out/bin/remote/vault/test
```